### PR TITLE
Use pinecone local instead of pinecone index in docker compose

### DIFF
--- a/docker-compose.pinecone.yaml
+++ b/docker-compose.pinecone.yaml
@@ -1,13 +1,11 @@
 services:
   pinecone:
-    image: ghcr.io/pinecone-io/pinecone-index:latest
+    image: ghcr.io/pinecone-io/pinecone-local:latest
     environment:
       PORT: 5080
-      INDEX_TYPE: serverless
-      DIMENSION: 2
-      METRIC: cosine
+      PINECONE_HOST: localhost
     ports:
-      - "5081:5081"
+      - "5080-6000:5080-6000"
     platform: linux/amd64
     # These labels ensure this service is discoverable by ddev.
     labels:

--- a/install.yaml
+++ b/install.yaml
@@ -94,6 +94,20 @@ post_install_actions:
   # - chmod +x ~/.ddev/commands/web/somecommand
   # - touch ${DDEV_APPROOT}/somefile.${GOOS}.${DDEV_WEBSERVER}
   # - perl -pi -e 's/oldstring/newstring/g' ${DDEV_APPROOT}/.ddev/docker-compose.pinecone.yaml
+  - curl -s "http://localhost:5080/indexes" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -d '{
+         "name": "example-index",
+         "dimension": 2,
+         "metric": "cosine",
+         "spec": {
+            "serverless": {
+               "cloud": "aws",
+               "region": "us-east-1"
+            }
+         }
+      }'
 
 # Shell actions that can be done during removal of the add-on.
 # Files listed in project_files section will be automatically removed here if they contain #ddev-generated line.


### PR DESCRIPTION
Switch from the pinecone index to the pinecone local container, with a plan to handle index creation through the install file.